### PR TITLE
Changed relative font style for numbers to make large amounts of text more readable

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -165,7 +165,7 @@ input::-webkit-input-placeholder {
     color: #aaa;
     content: counter(num-chars);
     display: block;
-    font-size: 1.5vw;
+    font-size: 0.15ch;
     text-align: center;
     user-select: none;
 }


### PR DESCRIPTION
Basically just messed with the css relative font styles and found something that makes it slightly more readable. Although honestly, you still have to zoom in to see the text when it's large amounts - but it's definitely not just looking at large numbers now. 