### PR TITLE
Fixed emoji display issue

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -29,8 +29,9 @@ window.addEventListener('DOMContentLoaded', function() {
         var fontSize = Math.min(150 / text.length, 30);
 
         clearChars();
+        
 
-        text.split('').forEach(function(chr) {
+        [...text].forEach(function(chr) {
             var charbox = charboxTemplate.content.cloneNode(true);
             var charElem = charbox.querySelector('.char');
             charElem.style.fontSize = fontSize + 'vw';


### PR DESCRIPTION
JavaScript's .split() function splits Unicode characters incorrectly, changing text.split() into [...text] is a quick solution for the problem, andnow displays emojis correctly.