### PR TITLE
Recognize Unicode letters instead of only ASCII

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -52,7 +52,7 @@ window.addEventListener('DOMContentLoaded', function() {
 
             if (chr.match(/[0-9]/i)) {
                 charElem.className = 'number';
-            } else if (!chr.match(/[a-z]/i)) {
+            } else if (!chr.match(/\p{L}/iu)) {
                 charElem.className = 'symbol';
             }
 


### PR DESCRIPTION
Based on https://stackoverflow.com/a/37668315/3499595

Checking [browser support](https://caniuse.com/mdn-javascript_builtins_regexp_unicode) looks like IE is not supported. Not sure if you're supporting it. If that's the case we could use the expansion directly.

**Before**

![image](https://user-images.githubusercontent.com/6631050/125208362-1d52cb80-e292-11eb-80f1-35031121cb15.png)

**After**

![image](https://user-images.githubusercontent.com/6631050/125208368-2cd21480-e292-11eb-84a1-71c7cfc55ec6.png)

